### PR TITLE
Update configuration location on Docker

### DIFF
--- a/server/docker.html
+++ b/server/docker.html
@@ -59,7 +59,7 @@ permalink: server/docker.html
 		</p>
 		<p>However, this won't be enough to keep a persistent ShokoServer instance running. We will add a few things to the
 			docker command to make sure we can survive a reboot after we make some changes. </p>
-		<pre class=".pre-scrollable">docker run -p 8111:8111 <b>-v "/path/to/config:/root/.shoko" -v "/path/to/webui:/usr/src/app/build/webui"</b> cazzar/shokoserver</pre>
+		<pre class=".pre-scrollable">docker run -p 8111:8111 <b>-v "/path/to/config:/.shoko" -v "/path/to/webui:/usr/src/app/build/webui"</b> cazzar/shokoserver</pre>
 		<h3>Command Breakdown</h3>
 		<table class="table table-striped">
 			<thead>
@@ -71,7 +71,7 @@ permalink: server/docker.html
 			<tbody>
 			<tr>
 				<td>
-					<pre class=".pre-scrollable">-v "/path/to/config:/root/.shoko"</pre>
+					<pre class=".pre-scrollable">-v "/path/to/config:/.shoko"</pre>
 				</td>
 				<td>Link the configuration file to a folder on your disk. This will allow for portability ease of use for
 					updates.
@@ -93,7 +93,7 @@ permalink: server/docker.html
 			Destination. </p>
 		<p>To add folders we can add another <strong>-v</strong> flag, you can keep adding as many as you need (one <strong>-v</strong>
 			for every folder). </p>
-		<pre class=".pre-scrollable">docker run -p 8111:8111 -v "/path/to/config:/root/.shoko" -v "/path/to/webui:/usr/src/app/build/webui" <b>-v "/path/to/anime:/anime"</b> cazzar/shokoserver</pre>
+		<pre class=".pre-scrollable">docker run -p 8111:8111 -v "/path/to/config:/.shoko" -v "/path/to/webui:/usr/src/app/build/webui" <b>-v "/path/to/anime:/anime"</b> cazzar/shokoserver</pre>
 		<p>
 			With ShokoServer up and running you can connect to it with ShokoDesktop or the WebUI, and start managing your
 			collection.</p>
@@ -114,7 +114,7 @@ ports:
 - "8111:8111"
 volumes:
 - "/path/to/Anime:/anime"
-- "/path/to/config:/root/.shoko"
+- "/path/to/config:/.shoko"
 - "/path/to/webui:/usr/src/app/build/webui"</pre>
 		<p>
 			This combines all of our previous configuration in an easy to read and edit format, and will allow you to create a

--- a/server/docker.html
+++ b/server/docker.html
@@ -60,6 +60,7 @@ permalink: server/docker.html
 		<p>However, this won't be enough to keep a persistent ShokoServer instance running. We will add a few things to the
 			docker command to make sure we can survive a reboot after we make some changes. </p>
 		<pre class=".pre-scrollable">docker run -p 8111:8111 <b>-v "/path/to/config:/root/.shoko" -v "/path/to/webui:/usr/src/app/build/webui"</b> cazzar/shokoserver</pre>
+    <p>Note, if you run the Docker container as any user other than the default root user, the configuration will be written to <code>/.shoko</code> instead as no user profile folder will exist. In this case, ensure you adjust the volume mount so that the ShokoServer data is preserved.</p>
 		<h3>Command Breakdown</h3>
 		<table class="table table-striped">
 			<thead>

--- a/server/docker.html
+++ b/server/docker.html
@@ -60,7 +60,7 @@ permalink: server/docker.html
 		<p>However, this won't be enough to keep a persistent ShokoServer instance running. We will add a few things to the
 			docker command to make sure we can survive a reboot after we make some changes. </p>
 		<pre class=".pre-scrollable">docker run -p 8111:8111 <b>-v "/path/to/config:/root/.shoko" -v "/path/to/webui:/usr/src/app/build/webui"</b> cazzar/shokoserver</pre>
-    <p>Note, if you run the Docker container as any user other than the default root user, the configuration will be written to <code>/.shoko</code> instead as no user profile folder will exist. In this case, ensure you adjust the volume mount so that the ShokoServer data is preserved.</p>
+		<p>Note, if you run the Docker container as any user other than the default root user, the configuration will be written to <code>/.shoko</code> instead as no user profile folder will exist. In this case, ensure you adjust the volume mount so that the ShokoServer data is preserved.</p>
 		<h3>Command Breakdown</h3>
 		<table class="table table-striped">
 			<thead>

--- a/server/docker.html
+++ b/server/docker.html
@@ -59,7 +59,7 @@ permalink: server/docker.html
 		</p>
 		<p>However, this won't be enough to keep a persistent ShokoServer instance running. We will add a few things to the
 			docker command to make sure we can survive a reboot after we make some changes. </p>
-		<pre class=".pre-scrollable">docker run -p 8111:8111 <b>-v "/path/to/config:/.shoko" -v "/path/to/webui:/usr/src/app/build/webui"</b> cazzar/shokoserver</pre>
+		<pre class=".pre-scrollable">docker run -p 8111:8111 <b>-v "/path/to/config:/root/.shoko" -v "/path/to/webui:/usr/src/app/build/webui"</b> cazzar/shokoserver</pre>
 		<h3>Command Breakdown</h3>
 		<table class="table table-striped">
 			<thead>
@@ -71,7 +71,7 @@ permalink: server/docker.html
 			<tbody>
 			<tr>
 				<td>
-					<pre class=".pre-scrollable">-v "/path/to/config:/.shoko"</pre>
+					<pre class=".pre-scrollable">-v "/path/to/config:/root/.shoko"</pre>
 				</td>
 				<td>Link the configuration file to a folder on your disk. This will allow for portability ease of use for
 					updates.
@@ -93,7 +93,7 @@ permalink: server/docker.html
 			Destination. </p>
 		<p>To add folders we can add another <strong>-v</strong> flag, you can keep adding as many as you need (one <strong>-v</strong>
 			for every folder). </p>
-		<pre class=".pre-scrollable">docker run -p 8111:8111 -v "/path/to/config:/.shoko" -v "/path/to/webui:/usr/src/app/build/webui" <b>-v "/path/to/anime:/anime"</b> cazzar/shokoserver</pre>
+		<pre class=".pre-scrollable">docker run -p 8111:8111 -v "/path/to/config:/root/.shoko" -v "/path/to/webui:/usr/src/app/build/webui" <b>-v "/path/to/anime:/anime"</b> cazzar/shokoserver</pre>
 		<p>
 			With ShokoServer up and running you can connect to it with ShokoDesktop or the WebUI, and start managing your
 			collection.</p>
@@ -114,7 +114,7 @@ ports:
 - "8111:8111"
 volumes:
 - "/path/to/Anime:/anime"
-- "/path/to/config:/.shoko"
+- "/path/to/config:/root/.shoko"
 - "/path/to/webui:/usr/src/app/build/webui"</pre>
 		<p>
 			This combines all of our previous configuration in an easy to read and edit format, and will allow you to create a


### PR DESCRIPTION
Hey there,

I was following the [Docker documentation for Shoko Server](http://docs.shokoanime.com/server/docker.html), but it looks like the file path in the documentation isn't the path that the Shoko server process attempts to use.

The documentation currently lists it as `/root/.shoko` however, when I ran Shoko for the first time with a volume mounted in that directory, I received an access denied error on `/.shoko`.

After changing my configuration mounted volume to be at `/.shoko` instead, it all seems to work and looking at the volume outside of the container I can see that it has successfully written files such as `settings.json` so i'm presuming that means it's working!

n.b. my setup is slightly special as i'm running the Shoko process with a custom UID so as to allow it to read/write some NFS shares where I actually store my media. I suspect if I didn't do this and I used the default UID of 1/root, Shoko would have been able to write successfully to this directory - however it wouldn't then be able to persist that configuration!