### PR TITLE
Added instructions for desktop under wine

### DIFF
--- a/content/en/faq-questions/general.md
+++ b/content/en/faq-questions/general.md
@@ -7,10 +7,16 @@
 Yes it Does!
 
 Using [Docker](https://www.docker.com/) you can run **Shoko Server** natively on Linux. We've created
-a [Linux Install Guide](/linux) that we highly recommend all Linux users follow to properly install Shoko Server. If
+a [Linux Install Guide](../server/install) that we highly recommend all Linux users follow to properly install Shoko Server. If
 needed, additional support can be found by visiting our **Discord Server**.
 
 Please keep in mind that Shoko Server on Linux is still in beta so issues are to be expected.
+
+{{% /faq %}} {{< faq-section type="general" >}} {{% faq type="general" id="linux-support-desktop" question="What about Shoko Desktop on Linux/MacOS?" %}}
+
+There are no plans to add Linux or MacOS support to **Shoko Desktop** as it is being phased out.
+
+Several community members have had success running the Windows client under Wine on [Linux](../server/linux-desktop) and on MacOS using the same wineprefix dependencies via Portingkit.
 
 {{% /faq %}} {{% faq type="general" id="anidb-ban" question="I've Been Banned From AniDB?" %}}
 

--- a/content/en/server/linux-desktop.md
+++ b/content/en/server/linux-desktop.md
@@ -1,0 +1,57 @@
++++ title = "Running Shoko Desktop on Linux"
+description = "Settings that work for Wine emulation"
+aliases = ["/server/linux-desktop"]
+layout = "single"
+[[pageNav]]
+name = "Shoko Desktop Under Linux"
+id = "desktop_on_linux"
+
++++
+
+## Desktop on Linux {.page-first-header}
+
+1. Download the latest Shoko Desktop latest (zip) from Github.
+    - Extracting to ```~/``` works fine, but you can also extract directly into the Wine environtment's virtual C:/ later.
+
+2.  Install the following from your distributions repository or flatpak
+    - winetricks
+    - Lutris *(optional as other tools can be used)*
+
+3. Launch winetricks to configure a wineprefix
+    - Choose create new wineprefix (x64_x86 is fine) and \<name it\>.
+    - Install a Windows DLL or component 
+        - d3dcompiler_47
+        - dotnet40 - prereq for dotnet 48
+        - dotnet48\*
+        - vcrun2013
+
+*You can now exit winetricks if it is still open.*
+
+
+**At this point the environment is ready and you may choose to use a different tool to proceed**
+
+## Lutris setup
+
+Launch Lutris
+1. Click the Add top left and configure the tabs per below
+    - Game info
+        - Name: *\<give it one\>*
+        - Runner: Wine (Runs Windows Games)
+    - Game options
+        - Executable: *\<path to ShokoDesktop.exe which will be wherever you extracted ShokoDesktop.zip to\>*
+        - Wine Prefix: *\<path to your prefix\>*
+        - Prefix architecture: Auto (default)
+    - Runner options
+        - Wine Version: System 7.0-rc6 (staging)) \*\*
+        - Use system winetricks - ON
+        - Enable DXVK - (OFF!)
+2. Save
+3. Launch the "game"
+
+*Note: You may get an rt error on launch, after dismissing the error everything should be fine.*
+    
+
+\*\* *The following runners have been tested and confirmed to be working*
+- 7.0 rc6
+- lutris-ge-6.16-1-x86_64
+- 6.10


### PR DESCRIPTION
- Fixed link to /linux in faq, now correctly targets /install
- added FAQ section for desktop under wine macos/linux
- added page for Linux instructions (I dont have a mac)

Not sure what tool you are using to convert the markdown in to html (honestly web stuff is not my wheelhouse :p)
The markdown looks good but that's all I can check currently