### PR TITLE
change case to resolve "Module not found" error

### DIFF
--- a/src/components/Changelog/Changelog.tsx
+++ b/src/components/Changelog/Changelog.tsx
@@ -1,6 +1,6 @@
 // Imports
 import React from 'react'
-import Lodash from 'Lodash'
+import Lodash from 'lodash'
 import { program, typeColor } from './Changelog.utils'
 
 export default function Changelog(props) {


### PR DESCRIPTION
Compiling gets `Module not found: Error: Can't resolve 'Lodash' in '/docusaurus/MyWebsite/src/components/Changelog'` and produces "cannot find module" when mouseover changelog.

![lodash](https://github.com/ShokoAnime/ShokoDocs/assets/39210984/f45bd194-be35-4aed-b018-728fcbe4b468)
