### PR TITLE
ShokoRelay: Minor doc changes / v1.1.7 -> v1.1.8

### DIFF
--- a/src/assets/data/changelog/shokorelay.json
+++ b/src/assets/data/changelog/shokorelay.json
@@ -2,6 +2,30 @@
   "githubLink": "https://github.com/natyusha/ShokoRelay.bundle",
   "releases": [
     {
+      "version": "1.1.8",
+      "versionURL": "118",
+      "date": "May 13th, 2024",
+      "link": "https://github.com/natyusha/ShokoRelay.bundle/releases/tag/v1.1.8",
+      "changes": [
+        {
+          "type": "added",
+          "text": "Added a requirements.txt for the scripts"
+        },
+        {
+          "type": "added",
+          "text": "Added an option to ignore air dates for negative seasons to workaround a playback order bug"
+        },
+        {
+          "type": "added",
+          "text": "Added an action for automatically creating a zipped release asset without anything appended to the folder name"
+        },
+        {
+          "type": "fixed",
+          "text": "Fixed an issue where episode metadata would not fully parse with SingleSeasonOrdering enabled"
+        }
+      ]
+    },
+    {
       "version": "1.1.7",
       "versionURL": "117",
       "date": "May 7th, 2024",

--- a/src/assets/data/changelog/shokorelay.json
+++ b/src/assets/data/changelog/shokorelay.json
@@ -2,6 +2,26 @@
   "githubLink": "https://github.com/natyusha/ShokoRelay.bundle",
   "releases": [
     {
+      "version": "1.1.7",
+      "versionURL": "117",
+      "date": "May 7th, 2024",
+      "link": "https://github.com/natyusha/ShokoRelay.bundle/releases/tag/v1.1.7",
+      "changes": [
+        {
+          "type": "added",
+          "text": "Added help pages for each of the scripts with -h or --help arguments"
+        },
+        {
+          "type": "added",
+          "text": "Added version information to the agent logs and Info.plist"
+        },
+        {
+          "type": "fixed",
+          "text": "Fixed a potential file lock issue with FFplay and animethemes.py"
+        }
+      ]
+    },
+    {
       "version": "1.1.6",
       "versionURL": "116",
       "date": "May 5th, 2024",

--- a/src/content/docs/plex-integration/configuring-shoko-relay.mdx
+++ b/src/content/docs/plex-integration/configuring-shoko-relay.mdx
@@ -316,7 +316,7 @@ If "assumed content ratings" are enabled in the agent settings the [target audie
         "TV-MA "
       ],
       [
-        "__\*\*\+__ Nudity, __\*\*__ sex",
+        "__\*\*\+__ Nudity, __\*\*__ Sex",
         "TV-MA-S"
       ],
       [

--- a/src/content/docs/plex-integration/shoko-relay-utility-scripts.mdx
+++ b/src/content/docs/plex-integration/shoko-relay-utility-scripts.mdx
@@ -154,6 +154,10 @@ This section is for remapping paths from Shoko's to the system where the scripts
 ## Running the Scripts
 Once the configuration has been completed simply run the scripts from a terminal. Arguments and example commands for each script will be listed below.
 
+:::tip
+Append `-h` or `--help` as an argument when running the scripts to access their help pages and avoid having to consult the readme for all of the commands.
+:::
+
 ### AnimeThemes
 Run in a terminal `animethemes.py` with the working directory set to a folder containing an anime series. If the anime has been matched by Shoko Server it will grab the anidbID and use that to match with an AnimeThemes anime entry.
 
@@ -192,7 +196,7 @@ Preview the 9th Opening of Bleach
 - `cd /d "X:\PathToBleach" && animethemes.py op9 play`
 
 ### Collection-Posters
-Run in a terminal `collection-posters.py` to set Plex collection posters to the user provided ones or Shoko's.
+Run in a terminal `collection-posters.py` to set Plex collection posters to user provided ones or Shoko's.
 - Any Posters in the "PostersFolder" must have the same name as their respective collection in Plex.
 - The following characters must be stripped from the filenames: \ / : * ? " < > |
 - The accepted file extension are: jpg / jpeg / png / tbn
@@ -201,7 +205,7 @@ Append the argument "clean" `collection-posters.py clean` if you want to remove 
 - This works by deleting everything but the newest custom poster for all collections.
 
 ### Force-Metadata
-Run in a terminal `force-metadata.py` to remove empty collections, rename negative seasons, normalise sort titles and add original titles. Append the argument "full" `force-metadata.py full` if you want to do a time consuming full metadata clean up.
+Run in a terminal `force-metadata.py` to remove empty collections, normalise collection sort titles, rename negative seasons and add original titles in Plex. Append the argument "full" `force-metadata.py full` if you want to do a time consuming full metadata clean up.
 
 :::caution[Warning]
 In "full" mode you must wait until the Plex activity queue is fully completed before advancing to the next step (with the enter key) or this will not function correctly.
@@ -210,7 +214,7 @@ In "full" mode you must wait until the Plex activity queue is fully completed be
 :::
 
 ### Rescan-Recent
-Run in a terminal `rescan-recent.py` to trigger a Plex rescan of the 5 most recently added series in Shoko. Append the number of recently added series (from 1-99) to rescan as an argument when 5 isn't enough:
+Run in a terminal `rescan-recent.py` to trigger a Plex rescan of the 5 most recently added series in Shoko. Change the number of recently added series (from 1-99) to rescan with an argument when 5 isn't enough:
 - `rescan-recent.py 20` would rescan the 20 most recently added series
 
 ### Watched-Sync


### PR DESCRIPTION
ShokoRelay now has a perma link for a zip file that doesn't have anything appended to the main folder name: https://github.com/natyusha/ShokoRelay.bundle/releases/latest/download/ShokoRelay.bundle.zip