### PR TITLE
Add instructions for installing ShokoServer bare-metal for Ubuntu

### DIFF
--- a/docs/getting-started/installing-shoko-server.md
+++ b/docs/getting-started/installing-shoko-server.md
@@ -133,6 +133,52 @@ AVDump3 may crash due to the inability to modify the shm_size in the proprietary
 As a result, we do not recommend running daily server on Synology NAS at this time.
 :::
 
+## TrueNAS Scale
+
+Follow these steps to set up a Shoko server using a custom app:
+
+1. Navigate to **Apps -> Discover Apps -> Custom App**.
+2. Set the **Application Name** to your preference.
+3. Configure **Container Images**:
+	- Image Repository: `ghcr.io/shokoanime/server`
+	- Image Tag: `latest`
+4. Set **Container Environment Variables**:
+	- These settings ensure Shoko runs as the built-in `Apps` user. Verify this user has access to your media folder.
+	  <EasyTable :columns="containerColumns" :data="containerData" />
+5. Configure **Port Forwarding**:
+	- Container Port: `8111`
+	- Node Port: Choose any available port
+ 	- Extra for Truenas EE: 
+	 	- Container Port: `4556`
+		- Host Port: `4556`
+	 	- Protocol: `udp` 
+6. Set up **Storage**:
+	- **Optional**: Mount Shoko config -> If not mounted the DB will be lost on container restart
+		- Host Path: Path to store Shoko config
+		- Mount Path: `/home/shoko/.shoko`
+	- **Required**: Mount media folder
+		- Host Path: Your media folder location
+		- Mount Path: Desired container media folder path
+7. Portal Configuration (**Optional**):
+	- Enable WebUiPortal: Checked
+	- Port: Use the Node Port from step 5. This allows access to the Shoko Web UI via the App's Web Portal.
+8. Container User and Group ID:
+	- If desired, leave as default to run as root.
+	- Configure to run with a user that has permission to modify files. Note: The Docker startup script will attempt to
+	  create a Shoko user and may fail to start if unsuccessful.
+9. Click **Save** and wait for the container status to change to "Running".
+10. Access the setup page by clicking **Web Portal** under Application Info.
+
+### Common Issues
+
+You may encounter the following issues when setting up Shoko Server with TrueNAS Scale:
+
+- Application is stuck in Deploying state:
+	- Navigate to **Workloads -> View Logs** to see what went wrong.
+- Shoko server does not see my media folder:
+	- Check the permissions on your media folder and ensure the user specified in the Container Environment Variables has
+	  access.
+
 ## Bare Metal (Ubuntu)
 
 :::danger 
@@ -235,53 +281,6 @@ When you first navigate to `http://localhost:8111`, you may see a message statin
 - Click on the **Install Shoko Server UI** button to proceed with the installation.
 - Once installed, you will be able to access and use the Shoko Server UI for managing your library.
 :::
-
-
-## TrueNAS Scale
-
-Follow these steps to set up a Shoko server using a custom app:
-
-1. Navigate to **Apps -> Discover Apps -> Custom App**.
-2. Set the **Application Name** to your preference.
-3. Configure **Container Images**:
-	- Image Repository: `ghcr.io/shokoanime/server`
-	- Image Tag: `latest`
-4. Set **Container Environment Variables**:
-	- These settings ensure Shoko runs as the built-in `Apps` user. Verify this user has access to your media folder.
-	  <EasyTable :columns="containerColumns" :data="containerData" />
-5. Configure **Port Forwarding**:
-	- Container Port: `8111`
-	- Node Port: Choose any available port
- 	- Extra for Truenas EE: 
-	 	- Container Port: `4556`
-		- Host Port: `4556`
-	 	- Protocol: `udp` 
-6. Set up **Storage**:
-	- **Optional**: Mount Shoko config -> If not mounted the DB will be lost on container restart
-		- Host Path: Path to store Shoko config
-		- Mount Path: `/home/shoko/.shoko`
-	- **Required**: Mount media folder
-		- Host Path: Your media folder location
-		- Mount Path: Desired container media folder path
-7. Portal Configuration (**Optional**):
-	- Enable WebUiPortal: Checked
-	- Port: Use the Node Port from step 5. This allows access to the Shoko Web UI via the App's Web Portal.
-8. Container User and Group ID:
-	- If desired, leave as default to run as root.
-	- Configure to run with a user that has permission to modify files. Note: The Docker startup script will attempt to
-	  create a Shoko user and may fail to start if unsuccessful.
-9. Click **Save** and wait for the container status to change to "Running".
-10. Access the setup page by clicking **Web Portal** under Application Info.
-
-### Common Issues
-
-You may encounter the following issues when setting up Shoko Server with TrueNAS Scale:
-
-- Application is stuck in Deploying state:
-	- Navigate to **Workloads -> View Logs** to see what went wrong.
-- Shoko server does not see my media folder:
-	- Check the permissions on your media folder and ensure the user specified in the Container Environment Variables has
-	  access.
 
 
 

--- a/docs/getting-started/installing-shoko-server.md
+++ b/docs/getting-started/installing-shoko-server.md
@@ -133,6 +133,110 @@ AVDump3 may crash due to the inability to modify the shm_size in the proprietary
 As a result, we do not recommend running daily server on Synology NAS at this time.
 :::
 
+## Bare Metal (Ubuntu)
+
+:::danger 
+This option is **not recommended** as it does not provide automatic updates. Manual updates must be performed whenever a new version is released.
+
+A higher-than-basic grasp of Linux is required to understand and follow these steps and troubleshoot any issues that may arise.
+:::
+
+#### Prerequisites
+- **Ubuntu 18.04** or later.
+
+#### 1. Update Your System
+```bash
+sudo apt update && sudo apt upgrade -y
+```
+
+#### 2. Install Required Dependencies
+```bash
+sudo apt install -y mediainfo librhash-dev
+```
+
+#### 3. Install .NET SDK and Runtime
+- Add the Microsoft package repository
+  ```bash
+  wget https://packages.microsoft.com/config/ubuntu/$(lsb_release -rs)/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
+  sudo dpkg -i packages-microsoft-prod.deb
+  sudo apt-get update
+  ```
+- Install the .NET runtime and SDK:
+  ```bash
+  sudo apt-get install -y dotnet-sdk-8.0 aspnetcore-runtime-8.0
+  ```
+
+#### 4. Download Shoko Server
+Download the latest release from the [Shoko Server Releases](https://github.com/ShokoAnime/ShokoServer/releases) page or use `wget`:
+```bash
+wget $(curl -s https://api.github.com/repos/ShokoAnime/ShokoServer/releases/latest | jq -r '.assets[] | select(.name | test("Shoko.CLI_Standalone_linux-x64.zip")) | .browser_download_url')
+```
+
+#### 5. Extract the Downloaded Archive
+```bash
+unzip Shoko.CLI_Standalone_linux-x64.zip -d ShokoServer
+cd ShokoServer
+```
+
+#### 6. Make the Shoko.CLI Executable
+```bash
+chmod +x Shoko.CLI
+```
+
+#### 7. Run Shoko Server
+```bash
+./Shoko.CLI
+```
+
+#### 8. Access the Web Interface
+Open your browser and navigate to:
+```
+http://localhost:8111
+```
+
+#### (Optional) Run Shoko Server as a Service
+To run Shoko Server as a background service:
+
+- Create a systemd service file with the following structure:
+  ```bash
+  sudo nano /etc/systemd/system/shokoserver.service
+  ```
+  ```ini
+  [Unit]
+  Description=Shoko Server
+  After=network.target
+
+  [Service]
+  Type=simple
+  User=username
+  ExecStart=/path/to/ShokoServer/publish/Shoko.CLI
+  WorkingDirectory=/path/to/ShokoServer/publish
+  Restart=always
+
+  [Install]
+  WantedBy=multi-user.target
+  ```
+- Replace `/path/to/ShokoServer` with the actual path to your Shoko Server directory, and `username` with the username you wish to use to run the service.
+
+- Reload systemd and enable the service:
+  ```bash
+  sudo systemctl daemon-reload
+  sudo systemctl enable shokoserver
+  sudo systemctl start shokoserver
+  ```
+- Check the status to ensure it’s running:
+  ```bash
+  sudo systemctl status shokoserver
+  ```
+
+:::tip
+When you first navigate to `http://localhost:8111`, you may see a message stating that "The Shoko Server UI is not installed."
+
+- Click on the **Install Shoko Server UI** button to proceed with the installation.
+- Once installed, you will be able to access and use the Shoko Server UI for managing your library.
+:::
+
+
 ## TrueNAS Scale
 
 Follow these steps to set up a Shoko server using a custom app:

--- a/docs/getting-started/installing-shoko-server.md
+++ b/docs/getting-started/installing-shoko-server.md
@@ -208,7 +208,7 @@ To run Shoko Server as a background service:
 
   [Service]
   Type=simple
-  User=username
+  User=1000
   ExecStart=/path/to/ShokoServer/publish/Shoko.CLI
   WorkingDirectory=/path/to/ShokoServer/publish
   Restart=always
@@ -216,7 +216,7 @@ To run Shoko Server as a background service:
   [Install]
   WantedBy=multi-user.target
   ```
-- Replace `/path/to/ShokoServer` with the actual path to your Shoko Server directory, and `username` with the username you wish to use to run the service.
+- Replace `/path/to/ShokoServer` with the actual path to your Shoko Server directory. `User=1000` will run the service as the default non-root Ubuntu user. Adjust this value if a different user is required.
 
 - Reload systemd and enable the service:
   ```bash

--- a/docs/getting-started/installing-shoko-server.md
+++ b/docs/getting-started/installing-shoko-server.md
@@ -169,12 +169,12 @@ sudo apt install -y mediainfo librhash-dev
 #### 4. Download Shoko Server
 Download the latest release from the [Shoko Server Releases](https://github.com/ShokoAnime/ShokoServer/releases) page or use `wget`:
 ```bash
-wget $(curl -s https://api.github.com/repos/ShokoAnime/ShokoServer/releases/latest | jq -r '.assets[] | select(.name | test("Shoko.CLI_Standalone_linux-x64.zip")) | .browser_download_url')
+wget $(curl -s https://api.github.com/repos/ShokoAnime/ShokoServer/releases/latest | jq -r '.assets[] | select(.name | test("Shoko.CLI_Framework_any-x64.zip")) | .browser_download_url')
 ```
 
 #### 5. Extract the Downloaded Archive
 ```bash
-unzip Shoko.CLI_Standalone_linux-x64.zip -d ShokoServer
+unzip Shoko.CLI_Framework_any-x64.zip -d ShokoServer
 cd ShokoServer
 ```
 

--- a/docs/getting-started/installing-shoko-server.md
+++ b/docs/getting-started/installing-shoko-server.md
@@ -182,9 +182,9 @@ You may encounter the following issues when setting up Shoko Server with TrueNAS
 ## Bare Metal (Ubuntu)
 
 :::danger 
-This option is **not recommended** as it does not provide automatic updates. Manual updates must be performed whenever a new version is released.
+This option is **not recommended** because it requires manual updates whenever a new version is released, as automatic updates are not available. 
 
-A higher-than-basic grasp of Linux is required to understand and follow these steps and troubleshoot any issues that may arise.
+Additionally, a strong understanding of Linux is needed to follow these steps and troubleshoot any issues that may occur. Please note that we are unable to provide direct support for installations performed using this method.
 :::
 
 #### Prerequisites


### PR DESCRIPTION
I noticed that the docs say:

```
Running Shoko directly on Linux (bare metal) is not advised due to the additional
complexity and skill required for proper installation.
```
 but don't actually say how to do so. I'm not sure if that's intentional or not, but I decided to throw together some instructions for how I installed it bare-metal on my Ubuntu server. I also added a warning advising that this way isn't actually recomended, and that you would need to manually update ShokoServer to get continuous updates (please correct me if I'm wrong there.)

Feel free to close this if you don't want this to be included in your documentation.

Thanks!