### PR TITLE
Shoko Relay: v1.2.26-1.2.27

### DIFF
--- a/docs/.vitepress/data/changelog/shokorelay.json
+++ b/docs/.vitepress/data/changelog/shokorelay.json
@@ -2,6 +2,38 @@
   "githubLink": "https://github.com/natyusha/ShokoRelay.bundle",
   "releases": [
     {
+      "version": "1.2.27",
+      "versionURL": "1227",
+      "date": "Apr 6th, 2025",
+      "link": "https://github.com/natyusha/ShokoRelay.bundle/releases/tag/v1.2.27",
+      "changes": [
+        {
+          "type": "added",
+          "text": "Added the ability to clear Plex's watched states via \"watched-sync.py purge\""
+        }
+      ]
+    },
+    {
+      "version": "1.2.26",
+      "versionURL": "1226",
+      "date": "Mar 23rd, 2025",
+      "link": "https://github.com/natyusha/ShokoRelay.bundle/releases/tag/v1.2.26",
+      "changes": [
+        {
+          "type": "fixed",
+          "text": "Fixed common title prefix modifications conflicting with \"force-metadata.py full\""
+        },
+        {
+          "type": "added",
+          "text": "Added an argument to trigger Shoko's \"Remove Missing Files\" action via \"rescan-recent.py remove\""
+        },
+        {
+          "type": "added",
+          "text": "Added some minor readme/Info.plist additions, clarifications and corrections"
+        }
+      ]
+    },
+    {
       "version": "1.2.25",
       "versionURL": "1225",
       "date": "Jan 27th, 2025",

--- a/docs/getting-started/available-programs-plugins.md
+++ b/docs/getting-started/available-programs-plugins.md
@@ -48,7 +48,7 @@ const pluginsData = [
     status: 'Active',
   },
   {
-    name: '[Shoko Relay](https://shokoanime.com/downloads/media-player-plugins/shokorelay)',
+    name: '[Shoko Relay](https://shokoanime.com/downloads/media-player-plugins/shoko-relay)',
     dev: 'natyusha',
     platform: 'Plex',
     status: 'Active',
@@ -60,7 +60,7 @@ const pluginsData = [
     status: 'Active',
   },
   {
-    name: '[Shokofin](https://shokoanime.com/downloads/media-player-plugins/shokodi)',
+    name: '[Shokodi](https://shokoanime.com/downloads/media-player-plugins/shokodi)',
     dev: 'Da3dsoul',
     platform: 'Kodi',
     status: 'Active',

--- a/docs/plex/configuring-shoko-relay.md
+++ b/docs/plex/configuring-shoko-relay.md
@@ -163,7 +163,7 @@ To resolve this there are several different approaches:
 In cases where metadata (generally posters) won't update there is a quick 3 step process to fix it:
 
 1. Navigate to the series → More "..." Button → Unmatch
-2. Settings → Manage → Troubleshooting → Clean Bundles + Optimize Database
+2. Settings → Manage → Troubleshooting → Clean Bundles
 3. Navigate back to the series → More "..." Button → Match → Select top result
 
 If this somehow still fails then a full [Plex Dance](https://forums.plex.tv/t/the-plex-dance/197064) is likely required.
@@ -263,26 +263,18 @@ it without splitting the series apart first.
 ##### Alternate Episode Ordering
 
 It is quite common for anime to have multiple ways of grouping the episodes into seasons. This includes: DVD/BD
-ordering, stream site listings or even manga story arcs. If you used Shoko while it still had TvDB support you may find
-that series in your Plex library are grouping differently than they used to be. Using Bleach as an example you can see
-that [TMDB](https://www.themoviedb.org/tv/30984-bleach/seasons) doesn't split the original run into seasons
-while [TvDB](https://thetvdb.com/series/bleach#seasons) does. Fortunately,
-TMDB's [Episode Groups](https://www.themoviedb.org/tv/30984-bleach/episode_groups) page provides alternate ordering
-options (often including TvDB's) in case you would like to use one of them instead.
+ordering, stream site listings or even manga story arcs. Using Bleach as an example you can see that [TMDB](https://www.themoviedb.org/tv/30984-bleach/seasons) doesn't split
+the original run into seasons while many people may expect it to. Fortunately, TMDB's [Episode Groups](https://www.themoviedb.org/tv/30984-bleach/episode_groups) page provides several
+alternate ordering options in case you would like to use one of those instead.
 
-If you have "Download Alternate Ordering" enabled under Shoko's "TMDB Download Options" this can be achieved using
-Shoko's `/Tmdb/Show/{showID}/Ordering/SetPreferred` v3 API endpoint which is available via [/swagger/](https://docs.shokoanime.com/faq#general).
+In order to select an alternate ordering for a series a few prerequisites must be met:
+- The series must have a TMDB link
+- TMDB's Episode Groups page for the series must have at least one entry
+- "Download Alternate Ordering" must be enabled under Shoko's "TMDB Download Options"
 
-Once you have authenticated with swagger, you can navigate to the previously mentioned endpoint. Using Bleach as an example once
-again, you would enter `30984` (Bleach's TMDB ID) into the `showID` box. Then you would the set the 16 character `AlternateOrderingID`
-in the request body to one of the ones available [here](https://www.themoviedb.org/tv/30984-bleach/episode_groups)
-(both IDs are available from the URL on TMDB). Lastly, click "Execute" and the order will be applied.
-
-```json
-{
-  "AlternateOrderingID": "663fb548c10d4be3e80b2f6d"
-}
-```
+If a series meets the above requirements simply navigate to it and click "Edit Link" (pencil next to the TMDB link) and then
+"Open Settings" (gear next to the TMDB title). From the now open "TMDB Show Settings" modal simply select the desired ordering
+and click Save.
 
 :::info
 If you select an alternate order for a series TMDB season posters will no longer be automatically added to Plex as those

--- a/docs/plex/shoko-relay-utility-scripts.md
+++ b/docs/plex/shoko-relay-utility-scripts.md
@@ -367,7 +367,7 @@ the readme for all of the commands.
 
 ### Watched-Sync
 
-- This script uses the Python-PlexAPI and Shoko Server to sync watched states from Plex to Shoko or Shoko to Plex.
+- This script uses the Python-PlexAPI and Shoko Server to sync watched states from Plex to Shoko or vice versa.
 - If something is marked as watched in Plex it will also be marked as watched in Shoko and AniDB.
 - This was created due to various issues with Plex and Shoko's built in watched status syncing.
   - Primarily, the webhook for syncing requires Plex Pass and does not account for things manually marked as watched.
@@ -394,11 +394,12 @@ the readme for all of the commands.
   - `watched-sync.py 2w` would return results from the last 2 weeks
   - `watched-sync.py 3d` would return results from the last 3 days
 - The full list of suffixes (from 1-999) are: m=minutes, h=hours, d=days, w=weeks, mon=months, y=years
-- Append the argument "import" `watched-sync.py import` if you want to sync watched states from Shoko to Plex instead.
-  - By default the script will ask for (Y/N) confirmation for each configured Plex user.
-  - This can be bypassed by adding the "force" flag (-f or --force).
+- There are two alternate modes for this script which will ask for (Y/N) confirmation for each configured Plex user.
+  - Append the argument "import" `watched-sync.py import` if you want to sync watched states from Shoko to Plex.
+  - Append the argument "purge" `watched-sync.py purge` if you want to remove all watched states from the configured Plex libraries.
+  - The confirmation prompts can be bypassed by adding the "force" flag (-f or --force).
 
 **Behaviour:**
 
-- Due to the potential for losing a huge amount of data removing watch states has been omitted from this script.
+- Due to the potential for losing a huge amount of data, removing watch states from Plex has been omitted from this script unless "purge" mode is used.
 :::


### PR DESCRIPTION
- update docs related to changes
- fix broken shoko relay link
- fix shokodi link name (still needs a valid url)